### PR TITLE
config: explicitly opt-out TLS

### DIFF
--- a/dist/examples/config.toml
+++ b/dist/examples/config.toml
@@ -1,8 +1,17 @@
+# Main service
 [service]
+# Listening address
 address = "127.0.0.1"
+# Listening port
 port = 9598
+# Whether to serve HTTP endpoints over TLS
+tls = false
 
+# Backends multiplexing
 [metrics.selectors]
+# Metrics source over normal file (by path)
 "daemon1" = { kind = "file", path = "/run/daemon1/public/metrics.promfile" }
+# Metrics source over unix-domain socket (streaming socket, by path)
 "daemon2" = { kind = "uds", path = "/run/daemon2/public/metrics.promsock" }
+# Metrics source over DBus protocol (by remote-call endpoint)
 "daemon3" = { kind = "dbus", path = "TODO" }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -10,6 +10,7 @@ import (
 type Settings struct {
 	ServiceAddress string
 	ServicePort    uint64
+	ServiceTLS     bool
 
 	Selectors map[string]backend.MetricsSource
 }
@@ -45,6 +46,7 @@ func defaultSettings() Settings {
 	return Settings{
 		ServiceAddress: "0.0.0.0",
 		ServicePort:    9598,
+		ServiceTLS:     true,
 
 		Selectors: make(map[string]backend.MetricsSource),
 	}
@@ -54,6 +56,9 @@ func defaultSettings() Settings {
 func validate(cfg Settings) error {
 	if len(cfg.Selectors) == 0 {
 		return errors.New("no selectors configured")
+	}
+	if cfg.ServiceTLS {
+		return errors.New("TLS mode not yet implemented")
 	}
 
 	return nil

--- a/internal/config/toml.go
+++ b/internal/config/toml.go
@@ -16,6 +16,7 @@ type tomlConfig struct {
 type serviceSection struct {
 	Address *string `toml:"address"`
 	Port    *uint64 `toml:"port"`
+	TLS     *bool   `toml:"tls"`
 }
 
 // metricsSection holds the optional `metrics` fragment
@@ -75,6 +76,9 @@ func mergeService(settings *Settings, cfg serviceSection) error {
 	}
 	if cfg.Port != nil {
 		settings.ServicePort = *cfg.Port
+	}
+	if cfg.TLS != nil {
+		settings.ServiceTLS = *cfg.TLS
 	}
 
 	return nil


### PR DESCRIPTION
While this doesn't implement TLS for now, users should
assume TLS is the default mode and opt-out in config.